### PR TITLE
Mitch

### DIFF
--- a/gpuPacer2022/codes/HIP/degridding/version0/utilities/Parameters.h
+++ b/gpuPacer2022/codes/HIP/degridding/version0/utilities/Parameters.h
@@ -20,7 +20,7 @@ typedef double Coord;           // T1
 typedef std::complex<Real> Value;    // T2
 
 // Can be changed for testing purposes
-const int NSAMPLES = 160'000;
+const int NSAMPLES = 160000;
 //const int NSAMPLES = 32;
 const int WSIZE = 33;
 const int NCHAN = 1;

--- a/gpuPacer2022/codes/HIP/degridding/version1/main.cpp
+++ b/gpuPacer2022/codes/HIP/degridding/version1/main.cpp
@@ -123,8 +123,10 @@ int main()
     const int SSIZE = 2 * support + 1;
     vector<Value> cpuGrid(GSIZE * GSIZE);
     cpuGrid.assign(cpuGrid.size(), static_cast<Value>(1.0));
+    //cpuGrid.assign(cpuGrid.size(), Value(1.0,1.0));
     vector<Value> gpuGrid(GSIZE * GSIZE);
     gpuGrid.assign(gpuGrid.size(), static_cast<Value>(1.0));
+    //gpuGrid.assign(gpuGrid.size(), Value(1.0,1.0));
 
     // printVector.printVector(u);
     // printVector.printVector(v);

--- a/gpuPacer2022/codes/HIP/degridding/version1/src/DegridderGPU.hip
+++ b/gpuPacer2022/codes/HIP/degridding/version1/src/DegridderGPU.hip
@@ -28,26 +28,23 @@ void degridHelper(const Complex* dGrid,
     hipDeviceProp_t devProp;
     hipGetDeviceProperties(&devProp, device);
 
+    cout << "maxGridSize "<<devProp.maxGridSize<<" maxThreadsPerBlock = "<<devProp.maxThreadsPerBlock << endl;
+    int gridSize = devProp.maxGridSize[0];  // launch kernels for this number of samples at a time
+    assert(SSIZE <= devProp.maxThreadsPerBlock);
+
     int count = 0;
-    int gridSize = 1024 * devProp.multiProcessorCount; // is starting size, will be reduced as required
     for (int dind = 0; dind < DSIZE; dind += gridSize)
     {
-        // if there are less than dimGrid elements left,
-        // do the remaining
+        // if there are less than dimGrid elements left, do the remaining
         if ((DSIZE - dind) < gridSize)
         {
             gridSize = DSIZE - dind;
         }
 
         ++count;
-        switch (support)
-        {
-        case 64:
-            devDegridKernel<64> <<< gridSize, SSIZE >>>(dGrid, GSIZE, dC, dCOffset, dIU, dIV, dData, dind);
-            break;
-        default:
-            assert(0);
-        }
+
+        devDegridKernel <<< gridSize, SSIZE >>>(dGrid, GSIZE, dC, support, dCOffset, dIU, dIV, dData, dind);
+
         gpuCheckErrors("cuda kernel launch failure");
     }
     cout << "Used " << count << " kernel launches." << endl;
@@ -101,7 +98,7 @@ void DegridderGPU<T2>::degridder()
 
     gpuErrchk(hipMemcpy(data.data(), dData, SIZE_DATA, hipMemcpyDeviceToHost));
     gpuCheckErrors("hipMemcpy D2H failure");
-
+    auto tD2H = omp_get_wtime();
 
     // Deallocate device vectors
     gpuErrchk(hipFree(dData));
@@ -111,18 +108,23 @@ void DegridderGPU<T2>::degridder()
     gpuErrchk(hipFree(dIU));
     gpuErrchk(hipFree(dIV));
     gpuCheckErrors("hipFree failure");
+    auto tFrees = omp_get_wtime();
     auto tFinal = omp_get_wtime();
 
     cout << "\nDegridderGPU IN MILLISECONDS:" << endl;
     cout << left << setw(21) << "hipMallocs"
          << left << setw(21) << "hipMemcpys (H2D)"
          << left << setw(21) << "kernel"
+         << left << setw(21) << "hipMemcpys (D2H)"
+         << left << setw(21) << "frees"
          << left << setw(21) << "total" << endl;;
 
     //cout << setprecision(2) << fixed;
     cout << left << setw(21) << (tAlloc - tInit) * 1000.0
          << left << setw(21) << (tH2D - tAlloc) * 1000.0
          << left << setw(21) << (tKernel - tH2D) * 1000.0 
+         << left << setw(21) << (tD2H - tKernel) * 1000.0
+         << left << setw(21) << (tFrees - tD2H) * 1000.0
          << left << setw(21) << (tFinal - tInit) * 1000.0 << endl;
 
 }

--- a/gpuPacer2022/codes/HIP/degridding/version1/src/DegridderGPU.hip
+++ b/gpuPacer2022/codes/HIP/degridding/version1/src/DegridderGPU.hip
@@ -29,7 +29,7 @@ void degridHelper(const Complex* dGrid,
     hipGetDeviceProperties(&devProp, device);
 
     cout << "maxGridSize "<<devProp.maxGridSize<<" maxThreadsPerBlock = "<<devProp.maxThreadsPerBlock << endl;
-    int gridSize = devProp.maxGridSize[0];  // launch kernels for this number of samples at a time
+    int gridSize = devProp.maxGridSize[0]/(SSIZE+1);  // launch kernels for this number of samples at a time
     assert(SSIZE <= devProp.maxThreadsPerBlock);
 
     int count = 0;

--- a/gpuPacer2022/codes/HIP/degridding/version1/src/DegridderGPU.hip
+++ b/gpuPacer2022/codes/HIP/degridding/version1/src/DegridderGPU.hip
@@ -1,6 +1,5 @@
 #include "DegridderGPU.h"
 
-#include <omp.h>
 #include <iomanip>
 
 using std::cout;
@@ -8,7 +7,6 @@ using std::endl;
 using std::vector;
 using std::complex;
 using std::left;
-using std::setprecision;
 using std::setw;
 using std::fixed;
 
@@ -28,7 +26,7 @@ void degridHelper(const Complex* dGrid,
     hipDeviceProp_t devProp;
     hipGetDeviceProperties(&devProp, device);
 
-    cout << "maxGridSize "<<devProp.maxGridSize<<" maxThreadsPerBlock = "<<devProp.maxThreadsPerBlock << endl;
+    //cout << "maxGridSize "<<devProp.maxGridSize[0]<<" maxThreadsPerBlock = "<<devProp.maxThreadsPerBlock << endl;
     int gridSize = devProp.maxGridSize[0]/(SSIZE+1);  // launch kernels for this number of samples at a time
     assert(SSIZE <= devProp.maxThreadsPerBlock);
 
@@ -55,7 +53,15 @@ template <typename T2>
 void DegridderGPU<T2>::degridder()
 {
     cout << "\nDegridding on GPU" << endl;
-    auto tInit = omp_get_wtime();
+
+    hipEvent_t start, stop;
+    hipEventCreate(&start);
+    hipEventCreate(&stop);
+    float tAlloc{ 0.0 }; // in milliseconds
+    float tH2D{ 0.0 }; // in milliseconds
+    float tKernel{ 0.0 }; // in milliseconds
+    float tD2H{ 0.0 }; // in milliseconds
+    float tFrees{ 0.0 }; // in milliseconds
 
     // Device parameters
     const size_t SIZE_DATA = data.size() * sizeof(T2);
@@ -73,6 +79,8 @@ void DegridderGPU<T2>::degridder()
     int* dIV;
 
     // Allocate device vectors
+    hipEventRecord(start);
+    hipEventSynchronize(start);
     gpuErrchk(hipMalloc(&dData, SIZE_DATA));
     gpuErrchk(hipMalloc(&dGrid, SIZE_GRID));
     gpuErrchk(hipMalloc(&dC, SIZE_C));
@@ -80,8 +88,12 @@ void DegridderGPU<T2>::degridder()
     gpuErrchk(hipMalloc(&dIU, SIZE_IU));
     gpuErrchk(hipMalloc(&dIV, SIZE_IV));
     gpuCheckErrors("hipMalloc failure");
-    auto tAlloc = omp_get_wtime();
+    hipEventRecord(stop);
+    hipEventSynchronize(stop);
+    hipEventElapsedTime(&tAlloc, start, stop);
 
+    hipEventRecord(start);
+    hipEventSynchronize(start);
     gpuErrchk(hipMemcpy(dData, data.data(), SIZE_DATA, hipMemcpyHostToDevice));
     gpuErrchk(hipMemcpy(dGrid, gpuGrid.data(), SIZE_GRID, hipMemcpyHostToDevice));
     gpuErrchk(hipMemcpy(dC, C.data(), SIZE_C, hipMemcpyHostToDevice));
@@ -89,18 +101,31 @@ void DegridderGPU<T2>::degridder()
     gpuErrchk(hipMemcpy(dIU, iu.data(), SIZE_IU, hipMemcpyHostToDevice));
     gpuErrchk(hipMemcpy(dIV, iv.data(), SIZE_IV, hipMemcpyHostToDevice));
     gpuCheckErrors("hipMemcpy H2D failure");
-    auto tH2D = omp_get_wtime();
+    hipEventRecord(stop);
+    hipEventSynchronize(stop);
+    hipEventElapsedTime(&tH2D, start, stop);
 
     // Kernel launch
+    hipEventRecord(start);
+    hipEventSynchronize(start);
     typedef hipComplex Complex;
-    degridHelper((const Complex*)dGrid, SSIZE, DSIZE, GSIZE, support, (const Complex*)dC, dCOffset, dIU, dIV, (Complex*)dData);
-    auto tKernel = omp_get_wtime();
+    degridHelper((const Complex*)dGrid, SSIZE, DSIZE, GSIZE, support,
+                 (const Complex*)dC, dCOffset, dIU, dIV, (Complex*)dData);
+    hipEventRecord(stop);
+    hipEventSynchronize(stop);
+    hipEventElapsedTime(&tKernel, start, stop);
 
+    hipEventRecord(start);
+    hipEventSynchronize(start);
     gpuErrchk(hipMemcpy(data.data(), dData, SIZE_DATA, hipMemcpyDeviceToHost));
     gpuCheckErrors("hipMemcpy D2H failure");
-    auto tD2H = omp_get_wtime();
+    hipEventRecord(stop);
+    hipEventSynchronize(stop);
+    hipEventElapsedTime(&tD2H, start, stop);
 
     // Deallocate device vectors
+    hipEventRecord(start);
+    hipEventSynchronize(start);
     gpuErrchk(hipFree(dData));
     gpuErrchk(hipFree(dGrid));
     gpuErrchk(hipFree(dC));
@@ -108,24 +133,25 @@ void DegridderGPU<T2>::degridder()
     gpuErrchk(hipFree(dIU));
     gpuErrchk(hipFree(dIV));
     gpuCheckErrors("hipFree failure");
-    auto tFrees = omp_get_wtime();
-    auto tFinal = omp_get_wtime();
+    hipEventRecord(stop);
+    hipEventSynchronize(stop);
+    hipEventElapsedTime(&tFrees, start, stop);
 
     cout << "\nDegridderGPU IN MILLISECONDS:" << endl;
     cout << left << setw(21) << "hipMallocs"
          << left << setw(21) << "hipMemcpys (H2D)"
          << left << setw(21) << "kernel"
          << left << setw(21) << "hipMemcpys (D2H)"
-         << left << setw(21) << "frees"
-         << left << setw(21) << "total" << endl;;
+         << left << setw(21) << "frees" << endl;;
 
-    //cout << setprecision(2) << fixed;
-    cout << left << setw(21) << (tAlloc - tInit) * 1000.0
-         << left << setw(21) << (tH2D - tAlloc) * 1000.0
-         << left << setw(21) << (tKernel - tH2D) * 1000.0 
-         << left << setw(21) << (tD2H - tKernel) * 1000.0
-         << left << setw(21) << (tFrees - tD2H) * 1000.0
-         << left << setw(21) << (tFinal - tInit) * 1000.0 << endl;
+    cout << left << setw(21) << tAlloc
+         << left << setw(21) << tH2D
+         << left << setw(21) << tKernel
+         << left << setw(21) << tD2H
+         << left << setw(21) << tFrees << endl;
+
+    hipEventDestroy(start);
+    hipEventDestroy(stop);
 
 }
 

--- a/gpuPacer2022/codes/HIP/degridding/version1/src/DegridderGPU.hip
+++ b/gpuPacer2022/codes/HIP/degridding/version1/src/DegridderGPU.hip
@@ -1,9 +1,16 @@
 #include "DegridderGPU.h"
 
+#include <omp.h>
+#include <iomanip>
+
 using std::cout;
 using std::endl;
 using std::vector;
 using std::complex;
+using std::left;
+using std::setprecision;
+using std::setw;
+using std::fixed;
 
 void degridHelper(const Complex* dGrid,
     const int SSIZE,
@@ -51,6 +58,7 @@ template <typename T2>
 void DegridderGPU<T2>::degridder()
 {
     cout << "\nDegridding on GPU" << endl;
+    auto tInit = omp_get_wtime();
 
     // Device parameters
     const size_t SIZE_DATA = data.size() * sizeof(T2);
@@ -75,6 +83,7 @@ void DegridderGPU<T2>::degridder()
     gpuErrchk(hipMalloc(&dIU, SIZE_IU));
     gpuErrchk(hipMalloc(&dIV, SIZE_IV));
     gpuCheckErrors("hipMalloc failure");
+    auto tAlloc = omp_get_wtime();
 
     gpuErrchk(hipMemcpy(dData, data.data(), SIZE_DATA, hipMemcpyHostToDevice));
     gpuErrchk(hipMemcpy(dGrid, gpuGrid.data(), SIZE_GRID, hipMemcpyHostToDevice));
@@ -83,10 +92,12 @@ void DegridderGPU<T2>::degridder()
     gpuErrchk(hipMemcpy(dIU, iu.data(), SIZE_IU, hipMemcpyHostToDevice));
     gpuErrchk(hipMemcpy(dIV, iv.data(), SIZE_IV, hipMemcpyHostToDevice));
     gpuCheckErrors("hipMemcpy H2D failure");
+    auto tH2D = omp_get_wtime();
 
     // Kernel launch
     typedef hipComplex Complex;
     degridHelper((const Complex*)dGrid, SSIZE, DSIZE, GSIZE, support, (const Complex*)dC, dCOffset, dIU, dIV, (Complex*)dData);
+    auto tKernel = omp_get_wtime();
 
     gpuErrchk(hipMemcpy(data.data(), dData, SIZE_DATA, hipMemcpyDeviceToHost));
     gpuCheckErrors("hipMemcpy D2H failure");
@@ -100,6 +111,20 @@ void DegridderGPU<T2>::degridder()
     gpuErrchk(hipFree(dIU));
     gpuErrchk(hipFree(dIV));
     gpuCheckErrors("hipFree failure");
+    auto tFinal = omp_get_wtime();
+
+    cout << "\nDegridderGPU IN MILLISECONDS:" << endl;
+    cout << left << setw(21) << "hipMallocs"
+         << left << setw(21) << "hipMemcpys (H2D)"
+         << left << setw(21) << "kernel"
+         << left << setw(21) << "total" << endl;;
+
+    //cout << setprecision(2) << fixed;
+    cout << left << setw(21) << (tAlloc - tInit) * 1000.0
+         << left << setw(21) << (tH2D - tAlloc) * 1000.0
+         << left << setw(21) << (tKernel - tH2D) * 1000.0 
+         << left << setw(21) << (tFinal - tInit) * 1000.0 << endl;
+
 }
 
 template void DegridderGPU<std::complex<float>>::degridder();

--- a/gpuPacer2022/codes/HIP/degridding/version1/src/DegridderGPU.hip
+++ b/gpuPacer2022/codes/HIP/degridding/version1/src/DegridderGPU.hip
@@ -27,7 +27,7 @@ void degridHelper(const Complex* dGrid,
     hipGetDeviceProperties(&devProp, device);
 
     //cout << "maxGridSize "<<devProp.maxGridSize[0]<<" maxThreadsPerBlock = "<<devProp.maxThreadsPerBlock << endl;
-    int gridSize = devProp.maxGridSize[0]/(SSIZE+1);  // launch kernels for this number of samples at a time
+    int gridSize = devProp.maxGridSize[0]/(support+1);  // launch kernels for this number of samples at a time
     assert(SSIZE <= devProp.maxThreadsPerBlock);
 
     int count = 0;

--- a/gpuPacer2022/codes/HIP/degridding/version1/src/degridKernelGPU.h
+++ b/gpuPacer2022/codes/HIP/degridding/version1/src/degridKernelGPU.h
@@ -4,12 +4,12 @@
 
 typedef hipComplex Complex;
 
-template <int support>
 __global__
 void devDegridKernel(
     const Complex* grid,
     const int GSIZE,
     const Complex* C,
+    const int support,
     const int* cOffset,
     const int* iu,
     const int* iv,

--- a/gpuPacer2022/codes/HIP/degridding/version1/src/degridKernelGPU.hip
+++ b/gpuPacer2022/codes/HIP/degridding/version1/src/degridKernelGPU.hip
@@ -1,31 +1,5 @@
 #include "degridKernelGPU.h"
-
-template <int support>
-__device__ Complex sumReduceWarpComplex(Complex val)
-{
-    const int offset = 2 * support;
-    volatile __shared__ float vals[offset * 2];
-
-    int i = threadIdx.x;
-    int lane = i & 31;
-    vals[i] = val.x;
-    vals[i + offset] = val.y;
-
-    float v = val.x;
-    if (lane >= 16)
-    {
-        i += offset;
-        v = val.y;
-    }
-
-    vals[i] = v = v + vals[i + 16];
-    vals[i] = v = v + vals[i + 8];
-    vals[i] = v = v + vals[i + 4];
-    vals[i] = v = v + vals[i + 2];
-    vals[i] = v = v + vals[i + 1];
-
-    return make_hipComplex(vals[threadIdx.x], vals[threadIdx.x + offset]);
-}
+#include <cassert>
 
 // launch_bounds__(2*support+1, 8)
 template <int support>
@@ -40,8 +14,14 @@ void devDegridKernel(
     Complex* data,
     const int dind)
 {
-    //printf("Hi there!\n");
-    const int dindLocal = dind + blockIdx.x;
+
+    const int bind = blockIdx.x;
+    const int tind = threadIdx.x;
+
+    const int dindLocal = dind + bind;
+
+    const int SSIZE = 2 * support + 1;
+    assert(SSIZE == blockDim.x);
 
     // The actual starting grid point
     __shared__ int gindShared;
@@ -49,7 +29,11 @@ void devDegridKernel(
     // The Convolution function point from which we offset
     __shared__ int cindShared;
 
-    if (threadIdx.x == 0)
+    // Shared memory buffer for the conv pixels in this block (data point)
+    __shared__ float sdata_re[SSIZE];
+    __shared__ float sdata_im[SSIZE];
+
+    if (tind == 0)
     {
         gindShared = iu[dindLocal] + GSIZE * iv[dindLocal] - support;
         cindShared = cOffset[dindLocal];
@@ -58,54 +42,136 @@ void devDegridKernel(
 
     Complex original = data[dindLocal];
 
-    const int SSIZE = 2 * support + 1;
-
-#pragma unroll 8
-    // row gives the support location in the v-direction
     for (int row = 0; row < SSIZE; ++row)
     {
         // Make a local copy from shared memory
         int gind = gindShared + GSIZE * row;
         int cind = cindShared + SSIZE * row;
 
-        Complex sum = hipCmulf(grid[gind + threadIdx.x], C[cind + threadIdx.x]);
-
-        // compute warp sums
-        int i = threadIdx.x;
-        if (i < SSIZE - 1)
+        if (tind < SSIZE)
         {
-            sum = sumReduceWarpComplex<support>(sum);
-        }
+            const Complex cpix = hipCmulf(grid[gind + tind], C[cind + tind]);
+            sdata_re[tind] = cpix.x;
+            sdata_im[tind] = cpix.y;
+            __syncthreads();
 
-        const int NUMWARPS = (2 * support) / 32;
-        __shared__ Complex dataShared[NUMWARPS + 1];
+            //DegridderGPU IN MILLISECONDS:
+            //hipMallocs           hipMemcpys (H2D)     kernel               total      original
+            //61.56                313.01               0.71                 422.21
+            //61.02                309.89               0.71                 418.36
+            //59.86                309.99               0.71                 418.27
+            //hipMallocs           hipMemcpys (H2D)     kernel               total      Reduction #1
+            //61.34                309.72               0.60                 416.65
+            //61.66                313.83               0.58                 419.82
+            //59.78                311.65               0.59                 417.04
+            //hipMallocs           hipMemcpys (H2D)     kernel               total      Reduction #2
+            //62.09                312.88               0.60                 421.94
+            //59.86                310.96               0.61                 416.64
+            //60.77                310.60               0.60                 418.89
+            //hipMallocs           hipMemcpys (H2D)     kernel               total      Reduction #3
+            //61.74                311.09               0.61                 421.11
+            //61.12                310.37               0.61                 419.66
+            //60.92                313.63               0.59                 421.76
+            //hipMallocs           hipMemcpys (H2D)     kernel               total      Reduction #4
+            //60.97                311.78               0.60                 417.27
+            //61.43                314.90               0.59                 421.45
+            //61.10                316.58               0.61                 424.42
 
-        int warp = i / 32;
-        int lane = threadIdx.x & 31;
+            // Reduction suggestions at https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf
 
-        if (lane == 0)
-        {
-            dataShared[warp] = sum;
-        }
+            // Note: This hasn't gone as far as separate warp reductions. The whole thing is reduced together.
+            //       Performance may be improved if separate warp reductions are used and loops are unrolled.
 
-        __syncthreads();
+            const int reduction = 4;
 
-        // combine warp sums 
-        if (i == 0)
-        {
-#pragma unroll
-            for (int w = 1; w < NUMWARPS + 1; w++)
+            switch (reduction)
             {
-                sum = hipCaddf(sum, dataShared[w]);
+            case 0: // this is the original case, which has been deleted (had a bug and hasn't been redone yet)
+                // assert(0);
+                break;
+            case 1: // Reduction #1
+                for(unsigned int s=1; s < SSIZE; s *= 2)
+                {
+                    if ((tind % (2*s) == 0) && (tind + s < SSIZE))
+                    {
+                        //sdata[tind] = hipCaddf(sdata[tind], sdata[tind + s]);
+                        sdata_re[tind] += sdata_re[tind + s];
+                        sdata_im[tind] += sdata_im[tind + s];
+                    }
+                    __syncthreads();
+                }
+                break;
+            case 2: // Reduction #2
+                for(unsigned int s=1; s < SSIZE; s *= 2)
+                {
+                    int index = 2 * s * tind;
+                    if (index + s < SSIZE) {
+                        //sdata[tind] = hipCaddf(sdata[tind], sdata[tind + s]);
+                        sdata_re[index] += sdata_re[index + s];
+                        sdata_im[index] += sdata_im[index + s];
+                    }
+                    __syncthreads();
+                }
+                break;
+            case 3: // Reduction #3
+                for(unsigned int s=SSIZE/2; s > 0; s /= 2)
+                {
+                    if ((tind < s) && (tind + s < SSIZE)) {
+                        //sdata[tind] = hipCaddf(sdata[tind], sdata[tind + s]);
+                        sdata_re[tind] += sdata_re[tind + s];
+                        sdata_im[tind] += sdata_im[tind + s];
+                    }
+                    __syncthreads();
+                }
+                // because SSIZE is odd, reduction #3 misses the last thread
+                if (tind == 0)
+                {
+                    sdata_re[tind] += sdata_re[SSIZE-1];
+                    sdata_im[tind] += sdata_im[SSIZE-1];
+                }
+                __syncthreads();
+                break;
+            case 4: // deal with imaginary parts if tind > s
+                for(unsigned int s=SSIZE/2; s > 0; s /= 2)
+                {
+                    // reduce the real part with threads 0:SSIZE/2
+                    if ((tind < s) && (tind + s < SSIZE)) {
+                        sdata_re[tind] += sdata_re[tind + s];
+                    }
+                    // reduce the imaginary part with threads SSIZE/2:SSIZE
+                    if ((tind > SSIZE-1-s) && (tind - s >= 0)) {
+                        sdata_im[tind] += sdata_im[tind - s];
+                    }
+                    __syncthreads();
+                }
+                // because SSIZE is odd, the real accumulation ends in the first thread but misses the last thread
+                // while the imaginary accumulation ends in the last thread but misses the first thread.
+                // So add the last to the first before moving on
+                if (tind == 0)
+                {
+                    sdata_re[tind] += sdata_re[SSIZE-1];
+                    sdata_im[tind] += sdata_im[SSIZE-1];
+                }
+                __syncthreads();
+                break;
+            default:
+                // assert(0);
+                break;
             }
 
-            original = hipCaddf(original, sum);
+        }
+
+        if (tind == 0)
+        {
+            original = hipCaddf(original, make_hipComplex(sdata_re[tind], sdata_im[tind]));
         }
     }
-    if (threadIdx.x == 0)
+
+    if (tind == 0)
     {
         data[dindLocal] = original;
     }
+
 }
 
 template
@@ -120,6 +186,3 @@ void devDegridKernel<64>(
     Complex* data,
     const int dind);
 
-template
-__device__
-Complex sumReduceWarpComplex<64>(Complex val);

--- a/gpuPacer2022/codes/HIP/degridding/version1/src/degridKernelGPU.hip
+++ b/gpuPacer2022/codes/HIP/degridding/version1/src/degridKernelGPU.hip
@@ -62,7 +62,8 @@ void devDegridKernel(
             // Note: This hasn't gone as far as separate warp reductions. The whole thing is reduced together.
             //       Performance may be improved if separate warp reductions are used and loops are unrolled.
 
-            const int reduction = 4;
+            // reductions 3 and 4 only work if support is a power of 2
+            const int reduction = 2;
 
             switch (reduction)
             {

--- a/gpuPacer2022/codes/HIP/degridding/version1/src/degridKernelGPU.hip
+++ b/gpuPacer2022/codes/HIP/degridding/version1/src/degridKernelGPU.hip
@@ -63,6 +63,7 @@ void devDegridKernel(
             //       Performance may be improved if separate warp reductions are used and loops are unrolled.
 
             // reductions 3 and 4 only work if support is a power of 2
+            // 2 and 3 seem to be the fastest from a small amount of testing. 1 is about twice as slow
             const int reduction = 2;
 
             switch (reduction)

--- a/gpuPacer2022/codes/HIP/degridding/version1/src/degridKernelGPU.hip
+++ b/gpuPacer2022/codes/HIP/degridding/version1/src/degridKernelGPU.hip
@@ -1,13 +1,15 @@
 #include "degridKernelGPU.h"
 #include <cassert>
 
-// launch_bounds__(2*support+1, 8)
-template <int support>
+// need a max size for the static shared memory vectors. Note that there are two of them.
+#define MAX_SSIZE 256
+
 __global__
 void devDegridKernel(
     const Complex* grid,
     const int GSIZE,
     const Complex* C,
+    const int support,
     const int* cOffset,
     const int* iu,
     const int* iv,
@@ -30,8 +32,8 @@ void devDegridKernel(
     __shared__ int cindShared;
 
     // Shared memory buffer for the conv pixels in this block (data point)
-    __shared__ float sdata_re[SSIZE];
-    __shared__ float sdata_im[SSIZE];
+    __shared__ float sdata_re[MAX_SSIZE];
+    __shared__ float sdata_im[MAX_SSIZE];
 
     if (tind == 0)
     {
@@ -54,28 +56,6 @@ void devDegridKernel(
             sdata_re[tind] = cpix.x;
             sdata_im[tind] = cpix.y;
             __syncthreads();
-
-            //DegridderGPU IN MILLISECONDS:
-            //hipMallocs           hipMemcpys (H2D)     kernel               total      original
-            //61.56                313.01               0.71                 422.21
-            //61.02                309.89               0.71                 418.36
-            //59.86                309.99               0.71                 418.27
-            //hipMallocs           hipMemcpys (H2D)     kernel               total      Reduction #1
-            //61.34                309.72               0.60                 416.65
-            //61.66                313.83               0.58                 419.82
-            //59.78                311.65               0.59                 417.04
-            //hipMallocs           hipMemcpys (H2D)     kernel               total      Reduction #2
-            //62.09                312.88               0.60                 421.94
-            //59.86                310.96               0.61                 416.64
-            //60.77                310.60               0.60                 418.89
-            //hipMallocs           hipMemcpys (H2D)     kernel               total      Reduction #3
-            //61.74                311.09               0.61                 421.11
-            //61.12                310.37               0.61                 419.66
-            //60.92                313.63               0.59                 421.76
-            //hipMallocs           hipMemcpys (H2D)     kernel               total      Reduction #4
-            //60.97                311.78               0.60                 417.27
-            //61.43                314.90               0.59                 421.45
-            //61.10                316.58               0.61                 424.42
 
             // Reduction suggestions at https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf
 
@@ -173,16 +153,4 @@ void devDegridKernel(
     }
 
 }
-
-template
-__global__
-void devDegridKernel<64>(
-    const Complex* grid,
-    const int GSIZE,
-    const Complex* C,
-    const int* cOffset,
-    const int* iu,
-    const int* iv,
-    Complex* data,
-    const int dind);
 

--- a/gpuPacer2022/codes/HIP/degridding/version1/utilities/MaxError.cpp
+++ b/gpuPacer2022/codes/HIP/degridding/version1/utilities/MaxError.cpp
@@ -27,7 +27,7 @@ void MaxError<complex<float>>::maxError(const std::vector<complex<float>>& v1, c
                 maximumErrorReal = abs(v1[i].real() - v2[i].real());
                 index = i;
                 cout << "Maximum Error: (" << maximumErrorReal << ", " << maximumErrorImag << "), at index: " << index << endl;
-                exit(-1);
+                //exit(-1);
             }
         }
         cout << "Maximum Error: (" << maximumErrorReal << ", " << maximumErrorImag << ")" << endl;

--- a/gpuPacer2022/codes/HIP/degridding/version1/utilities/Parameters.h
+++ b/gpuPacer2022/codes/HIP/degridding/version1/utilities/Parameters.h
@@ -20,7 +20,7 @@ typedef double Coord;           // T1
 typedef std::complex<Real> Value;    // T2
 
 // Can be changed for testing purposes
-const int NSAMPLES = 160'000;
+const int NSAMPLES = 160000;
 //const int NSAMPLES = 32;
 const int WSIZE = 33;
 const int NCHAN = 1;

--- a/gpuPacer2022/codes/HIP/gridding/version0/utilities/Parameters.h
+++ b/gpuPacer2022/codes/HIP/gridding/version0/utilities/Parameters.h
@@ -20,7 +20,7 @@ typedef double Coord;           // T1
 typedef std::complex<Real> Value;    // T2
 
 // Can be changed for testing purposes
-const int NSAMPLES = 160'000;
+const int NSAMPLES = 160000;
 //const int NSAMPLES = 32;
 const int WSIZE = 33;
 const int NCHAN = 1;

--- a/gpuPacer2022/codes/HIP/gridding/version1/src/GridderGPU.hip
+++ b/gpuPacer2022/codes/HIP/gridding/version1/src/GridderGPU.hip
@@ -122,7 +122,7 @@ void GridderGPU<T2>::gridder()
         hipDeviceProp_t devProp;
         hipGetDeviceProperties(&devProp, device);
  
-        int gridSize = devProp.maxGridSize[0]/(SSIZE+1);  // launch kernels for this number of samples at a time
+        int gridSize = devProp.maxGridSize[0]/(support+1);  // launch kernels for this number of samples at a time
         assert(SSIZE <= devProp.maxThreadsPerBlock);
 
         int count = 0;

--- a/gpuPacer2022/codes/HIP/gridding/version1/src/GridderGPU.hip
+++ b/gpuPacer2022/codes/HIP/gridding/version1/src/GridderGPU.hip
@@ -75,18 +75,6 @@ void GridderGPU<T2>::gridder()
     so subsequent calls to gridStep() overlap with the actual gridding.
     */
 
-    /*
-hipMallocs           hipMemcpys (H2D)     kernel               total    kernel = 1
-0.42                 306.52               170.12               498.91
-0.42                 547.06               173.82               746.23
-0.41                 307.65               168.72               499.25
-hipMallocs           hipMemcpys (H2D)     kernel               total    kernel = 2
-0.41                 307.09               0.71                 418.19
-0.41                 309.07               0.60                 418.99
-0.40                 305.27               0.67                 415.78
-    */
-
-
     const int kernel = 2;
 
     if (kernel == 1) {
@@ -99,7 +87,8 @@ hipMallocs           hipMemcpys (H2D)     kernel               total    kernel =
             step = gridStep(DSIZE, SSIZE, dind, iu, iv);
             dim3 gridDim(SSIZE, step);
             /// PJE: make sure any chevron is tightly packed
-            devGridKernel1 <<<gridDim, SSIZE >>>((const Complex*)dData, support, (const Complex*)dC, dCOffset, dIU, dIV, (Complex*)dGrid, GSIZE, dind);
+            devGridKernel1 <<<gridDim, SSIZE >>>((const Complex*)dData, support, (const Complex*)dC,
+                                                 dCOffset, dIU, dIV, (Complex*)dGrid, GSIZE, dind);
             gpuCheckErrors("kernel launch (devGridKernel_v0) failure");
             count++;
         }
@@ -114,26 +103,23 @@ hipMallocs           hipMemcpys (H2D)     kernel               total    kernel =
         hipDeviceProp_t devProp;
         hipGetDeviceProperties(&devProp, device);
  
+        int gridSize = devProp.maxGridSize[0];  // launch kernels for this number of samples at a time
+        assert(SSIZE <= devProp.maxThreadsPerBlock);
+
         int count = 0;
-        int gridSize = 1024 * devProp.multiProcessorCount; // is starting size, will be reduced as required
         for (int dind = 0; dind < DSIZE; dind += gridSize)
         {
-            // if there are less than dimGrid elements left,
-            // do the remaining
+            // if there are less than dimGrid elements left, do the remaining
             if ((DSIZE - dind) < gridSize)
             {
                 gridSize = DSIZE - dind;
             }
  
             ++count;
-            switch (support)
-            {
-            case 64:
-                devGridKernel2 <<< gridSize, SSIZE >>>((const Complex*)dData, support, (const Complex*)dC, dCOffset, dIU, dIV, (Complex*)dGrid, GSIZE, dind);
-                break;
-            default:
-                assert(0);
-            }
+
+            devGridKernel2 <<< gridSize, SSIZE >>>((const Complex*)dData, support, (const Complex*)dC,
+                                                   dCOffset, dIU, dIV, (Complex*)dGrid, GSIZE, dind);
+
             gpuCheckErrors("cuda kernel launch failure");
         }
         cout << "Used " << count << " kernel launches." << endl;

--- a/gpuPacer2022/codes/HIP/gridding/version1/src/GridderGPU.hip
+++ b/gpuPacer2022/codes/HIP/gridding/version1/src/GridderGPU.hip
@@ -1,13 +1,12 @@
 #include "GridderGPU.h"
 
-#include <omp.h>
 #include <iomanip>
+
 using std::cout;
 using std::endl;
 using std::vector;
 using std::complex;
 using std::left;
-using std::setprecision;
 using std::setw;
 using std::fixed;
 
@@ -17,7 +16,15 @@ template <typename T2>
 void GridderGPU<T2>::gridder()
 {
     cout << "\nGridding on GPU" << endl;
-    auto tInit = omp_get_wtime();
+
+    hipEvent_t start, stop;
+    hipEventCreate(&start);
+    hipEventCreate(&stop);
+    float tAlloc{ 0.0 }; // in milliseconds
+    float tH2D{ 0.0 }; // in milliseconds
+    float tKernel{ 0.0 }; // in milliseconds
+    float tD2H{ 0.0 }; // in milliseconds
+    float tFrees{ 0.0 }; // in milliseconds
 
     // Device parameters
     const size_t SIZE_DATA = data.size() * sizeof(T2);
@@ -35,6 +42,8 @@ void GridderGPU<T2>::gridder()
     int* dIV;
 
     // Allocate device vectors
+    hipEventRecord(start);
+    hipEventSynchronize(start);
     gpuErrchk(hipMalloc(&dData, SIZE_DATA));
     gpuErrchk(hipMalloc(&dGrid, SIZE_GRID));
     gpuErrchk(hipMalloc(&dC, SIZE_C));
@@ -42,8 +51,12 @@ void GridderGPU<T2>::gridder()
     gpuErrchk(hipMalloc(&dIU, SIZE_IU));
     gpuErrchk(hipMalloc(&dIV, SIZE_IV));
     gpuCheckErrors("hipMalloc failure");
-    auto tAlloc = omp_get_wtime();
+    hipEventRecord(stop);
+    hipEventSynchronize(stop);
+    hipEventElapsedTime(&tAlloc, start, stop);
 
+    hipEventRecord(start);
+    hipEventSynchronize(start);
     gpuErrchk(hipMemcpy(dData, data.data(), SIZE_DATA, hipMemcpyHostToDevice));
     gpuErrchk(hipMemcpy(dGrid, gpuGrid.data(), SIZE_GRID, hipMemcpyHostToDevice));
     gpuErrchk(hipMemcpy(dC, C.data(), SIZE_C, hipMemcpyHostToDevice));
@@ -51,7 +64,9 @@ void GridderGPU<T2>::gridder()
     gpuErrchk(hipMemcpy(dIU, iu.data(), SIZE_IU, hipMemcpyHostToDevice));
     gpuErrchk(hipMemcpy(dIV, iv.data(), SIZE_IV, hipMemcpyHostToDevice));
     gpuCheckErrors("hipMemcpy H2D failure");
-    auto tH2D = omp_get_wtime();
+    hipEventRecord(stop);
+    hipEventSynchronize(stop);
+    hipEventElapsedTime(&tH2D, start, stop);
 
     /*******************************************************************************************************/
     /*******************************************************************************************************/
@@ -61,25 +76,29 @@ void GridderGPU<T2>::gridder()
     typedef hipComplex Complex;
 
     const int SSIZE = 2 * support + 1;
-    int step = 1;
 
-    /*
-    This loop steps through each spectral sample
-    either 1 or 2 at a time. It will do multiple samples
-    if the regions involved do not overlap. If they do,
-    only the non-overlapping samples are gridded.
-
-    Gridding multiple points is better, because giving the
-    GPU more work to do allows it to hide memory latency
-    better. The call to d_gridKernel() is asynchronous
-    so subsequent calls to gridStep() overlap with the actual gridding.
-    */
+    hipEventRecord(start);
+    hipEventSynchronize(start);
 
     const int kernel = 2;
 
     if (kernel == 1) {
 
+        /*
+        This loop steps through each spectral sample
+        either 1 or 2 at a time. It will do multiple samples
+        if the regions involved do not overlap. If they do,
+        only the non-overlapping samples are gridded.
+ 
+        Gridding multiple points is better, because giving the
+        GPU more work to do allows it to hide memory latency
+        better. The call to d_gridKernel() is asynchronous
+        so subsequent calls to gridStep() overlap with the actual gridding.
+        */
+
         hipFuncSetCacheConfig(reinterpret_cast<const void*>(devGridKernel1), hipFuncCachePreferL1);
+
+        int step = 1;
 
         int count = 0;
         for (int dind = 0; dind < DSIZE; dind += step)
@@ -126,12 +145,21 @@ void GridderGPU<T2>::gridder()
 
     }
 
-    auto tKernel = omp_get_wtime();
+    hipEventRecord(stop);
+    hipEventSynchronize(stop);
+    hipEventElapsedTime(&tKernel, start, stop);
 
+    hipEventRecord(start);
+    hipEventSynchronize(start);
     gpuErrchk(hipMemcpy(gpuGrid.data(), dGrid, SIZE_GRID, hipMemcpyDeviceToHost));
     gpuCheckErrors("hipMemcpy D2H failure");
+    hipEventRecord(stop);
+    hipEventSynchronize(stop);
+    hipEventElapsedTime(&tD2H, start, stop);
 
     // Deallocate device vectors
+    hipEventRecord(start);
+    hipEventSynchronize(start);
     gpuErrchk(hipFree(dData));
     gpuErrchk(hipFree(dGrid));
     gpuErrchk(hipFree(dC));
@@ -139,19 +167,22 @@ void GridderGPU<T2>::gridder()
     gpuErrchk(hipFree(dIU));
     gpuErrchk(hipFree(dIV));
     gpuCheckErrors("hipFree failure");
-    auto tFinal = omp_get_wtime();
+    hipEventRecord(stop);
+    hipEventSynchronize(stop);
+    hipEventElapsedTime(&tFrees, start, stop);
 
     cout << "\nDegridderGPU IN MILLISECONDS:" << endl;
     cout << left << setw(21) << "hipMallocs"
          << left << setw(21) << "hipMemcpys (H2D)"
          << left << setw(21) << "kernel"
-         << left << setw(21) << "total" << endl;;
+         << left << setw(21) << "hipMemcpys (D2H)"
+         << left << setw(21) << "frees" << endl;;
 
-    //cout << setprecision(2) << fixed;
-    cout << left << setw(21) << (tAlloc - tInit) * 1000.0
-         << left << setw(21) << (tH2D - tAlloc) * 1000.0
-         << left << setw(21) << (tKernel - tH2D) * 1000.0 
-         << left << setw(21) << (tFinal - tInit) * 1000.0 << endl;
+    cout << left << setw(21) << tAlloc
+         << left << setw(21) << tH2D
+         << left << setw(21) << tKernel
+         << left << setw(21) << tD2H
+         << left << setw(21) << tFrees << endl;
 }
 
 int gridStep(const int DSIZE, const int SSIZE, const int dind, const std::vector<int>& iu, const std::vector<int>& iv)

--- a/gpuPacer2022/codes/HIP/gridding/version1/src/GridderGPU.hip
+++ b/gpuPacer2022/codes/HIP/gridding/version1/src/GridderGPU.hip
@@ -103,7 +103,7 @@ void GridderGPU<T2>::gridder()
         hipDeviceProp_t devProp;
         hipGetDeviceProperties(&devProp, device);
  
-        int gridSize = devProp.maxGridSize[0];  // launch kernels for this number of samples at a time
+        int gridSize = devProp.maxGridSize[0]/(SSIZE+1);  // launch kernels for this number of samples at a time
         assert(SSIZE <= devProp.maxThreadsPerBlock);
 
         int count = 0;

--- a/gpuPacer2022/codes/HIP/gridding/version1/src/GridderGPU.hip
+++ b/gpuPacer2022/codes/HIP/gridding/version1/src/GridderGPU.hip
@@ -1,9 +1,15 @@
 #include "GridderGPU.h"
 
+#include <omp.h>
+#include <iomanip>
 using std::cout;
 using std::endl;
 using std::vector;
 using std::complex;
+using std::left;
+using std::setprecision;
+using std::setw;
+using std::fixed;
 
 int gridStep(const int DSIZE, const int SSIZE, const int dind, const std::vector<int>&iu, const std::vector<int>&iv);
 
@@ -11,6 +17,7 @@ template <typename T2>
 void GridderGPU<T2>::gridder()
 {
     cout << "\nGridding on GPU" << endl;
+    auto tInit = omp_get_wtime();
 
     // Device parameters
     const size_t SIZE_DATA = data.size() * sizeof(T2);
@@ -35,6 +42,7 @@ void GridderGPU<T2>::gridder()
     gpuErrchk(hipMalloc(&dIU, SIZE_IU));
     gpuErrchk(hipMalloc(&dIV, SIZE_IV));
     gpuCheckErrors("hipMalloc failure");
+    auto tAlloc = omp_get_wtime();
 
     gpuErrchk(hipMemcpy(dData, data.data(), SIZE_DATA, hipMemcpyHostToDevice));
     gpuErrchk(hipMemcpy(dGrid, gpuGrid.data(), SIZE_GRID, hipMemcpyHostToDevice));
@@ -43,6 +51,7 @@ void GridderGPU<T2>::gridder()
     gpuErrchk(hipMemcpy(dIU, iu.data(), SIZE_IU, hipMemcpyHostToDevice));
     gpuErrchk(hipMemcpy(dIV, iv.data(), SIZE_IV, hipMemcpyHostToDevice));
     gpuCheckErrors("hipMemcpy H2D failure");
+    auto tH2D = omp_get_wtime();
 
     /*******************************************************************************************************/
     /*******************************************************************************************************/
@@ -50,7 +59,6 @@ void GridderGPU<T2>::gridder()
     cout << "Kernel launch" << endl;
     const size_t DSIZE = data.size();
     typedef hipComplex Complex;
-    hipFuncSetCacheConfig(reinterpret_cast<const void*>(devGridKernel), hipFuncCachePreferL1);
 
     const int SSIZE = 2 * support + 1;
     int step = 1;
@@ -67,17 +75,72 @@ void GridderGPU<T2>::gridder()
     so subsequent calls to gridStep() overlap with the actual gridding.
     */
 
-    int count = 0;
-    for (int dind = 0; dind < DSIZE; dind += step)
-    {
-        step = gridStep(DSIZE, SSIZE, dind, iu, iv);
-        dim3 gridDim(SSIZE, step);
-        /// PJE: make sure any chevron is tightly packed
-        devGridKernel <<<gridDim, SSIZE >>>((const Complex*)dData, support, (const Complex*)dC, dCOffset, dIU, dIV, (Complex*)dGrid, GSIZE, dind);
-        gpuCheckErrors("kernel launch (devGridKernel_v0) failure");
-        count++;
+    /*
+hipMallocs           hipMemcpys (H2D)     kernel               total    kernel = 1
+0.42                 306.52               170.12               498.91
+0.42                 547.06               173.82               746.23
+0.41                 307.65               168.72               499.25
+hipMallocs           hipMemcpys (H2D)     kernel               total    kernel = 2
+0.41                 307.09               0.71                 418.19
+0.41                 309.07               0.60                 418.99
+0.40                 305.27               0.67                 415.78
+    */
+
+
+    const int kernel = 2;
+
+    if (kernel == 1) {
+
+        hipFuncSetCacheConfig(reinterpret_cast<const void*>(devGridKernel1), hipFuncCachePreferL1);
+
+        int count = 0;
+        for (int dind = 0; dind < DSIZE; dind += step)
+        {
+            step = gridStep(DSIZE, SSIZE, dind, iu, iv);
+            dim3 gridDim(SSIZE, step);
+            /// PJE: make sure any chevron is tightly packed
+            devGridKernel1 <<<gridDim, SSIZE >>>((const Complex*)dData, support, (const Complex*)dC, dCOffset, dIU, dIV, (Complex*)dGrid, GSIZE, dind);
+            gpuCheckErrors("kernel launch (devGridKernel_v0) failure");
+            count++;
+        }
+        cout << "Used " << count << " kernel launches." << endl;
+
+    } else {
+
+        hipFuncSetCacheConfig(reinterpret_cast<const void*>(devGridKernel2), hipFuncCachePreferL1);
+
+        int device;
+        hipGetDevice(&device);
+        hipDeviceProp_t devProp;
+        hipGetDeviceProperties(&devProp, device);
+ 
+        int count = 0;
+        int gridSize = 1024 * devProp.multiProcessorCount; // is starting size, will be reduced as required
+        for (int dind = 0; dind < DSIZE; dind += gridSize)
+        {
+            // if there are less than dimGrid elements left,
+            // do the remaining
+            if ((DSIZE - dind) < gridSize)
+            {
+                gridSize = DSIZE - dind;
+            }
+ 
+            ++count;
+            switch (support)
+            {
+            case 64:
+                devGridKernel2 <<< gridSize, SSIZE >>>((const Complex*)dData, support, (const Complex*)dC, dCOffset, dIU, dIV, (Complex*)dGrid, GSIZE, dind);
+                break;
+            default:
+                assert(0);
+            }
+            gpuCheckErrors("cuda kernel launch failure");
+        }
+        cout << "Used " << count << " kernel launches." << endl;
+
     }
-    cout << "Used " << count << " kernel launches." << endl;
+
+    auto tKernel = omp_get_wtime();
 
     gpuErrchk(hipMemcpy(gpuGrid.data(), dGrid, SIZE_GRID, hipMemcpyDeviceToHost));
     gpuCheckErrors("hipMemcpy D2H failure");
@@ -90,6 +153,19 @@ void GridderGPU<T2>::gridder()
     gpuErrchk(hipFree(dIU));
     gpuErrchk(hipFree(dIV));
     gpuCheckErrors("hipFree failure");
+    auto tFinal = omp_get_wtime();
+
+    cout << "\nDegridderGPU IN MILLISECONDS:" << endl;
+    cout << left << setw(21) << "hipMallocs"
+         << left << setw(21) << "hipMemcpys (H2D)"
+         << left << setw(21) << "kernel"
+         << left << setw(21) << "total" << endl;;
+
+    //cout << setprecision(2) << fixed;
+    cout << left << setw(21) << (tAlloc - tInit) * 1000.0
+         << left << setw(21) << (tH2D - tAlloc) * 1000.0
+         << left << setw(21) << (tKernel - tH2D) * 1000.0 
+         << left << setw(21) << (tFinal - tInit) * 1000.0 << endl;
 }
 
 int gridStep(const int DSIZE, const int SSIZE, const int dind, const std::vector<int>& iu, const std::vector<int>& iv)

--- a/gpuPacer2022/codes/HIP/gridding/version1/src/gridKernelGPU.h
+++ b/gpuPacer2022/codes/HIP/gridding/version1/src/gridKernelGPU.h
@@ -5,7 +5,19 @@
 typedef hipComplex Complex;
 
 __global__
-void devGridKernel(
+void devGridKernel1(
+    const Complex* data,
+    const int support,
+    const Complex* C,
+    const int* cOffset,
+    const int* iu,
+    const int* iv,
+    Complex* grid,
+    const int GSIZE,
+    const int dind);
+
+__global__
+void devGridKernel2(
     const Complex* data,
     const int support,
     const Complex* C,

--- a/gpuPacer2022/codes/HIP/gridding/version1/src/gridKernelGPU.hip
+++ b/gpuPacer2022/codes/HIP/gridding/version1/src/gridKernelGPU.hip
@@ -1,7 +1,7 @@
 #include "gridKernelGPU.h"
 
 __global__
-void devGridKernel(
+void devGridKernel1(
     const Complex* data,
     const int support,
     const Complex* C,
@@ -47,4 +47,64 @@ void devGridKernel(
 
     // threadIdx.x gives the support location in the u direction
     grid[gind + threadIdx.x] = hipCfmaf(dataLocal, C[cind + threadIdx.x], grid[gind + threadIdx.x]);
+}
+
+__global__
+void devGridKernel2(
+    const Complex* data,
+    const int support,
+    const Complex* C,
+    const int* cOffset,
+    const int* iu,
+    const int* iv,
+    Complex* grid,
+    const int GSIZE,
+    const int dind)
+{
+
+    const int bind = blockIdx.x;
+    const int tind = threadIdx.x;
+
+    const int dindLocal = dind + bind;
+
+    const int SSIZE = 2 * support + 1;
+    assert(SSIZE == blockDim.x);
+
+    // The actual starting grid point
+    __shared__ int gindShared;
+
+    // The Convolution function point from which we offset
+    __shared__ int cindShared;
+
+    __shared__ Complex dataLocal;
+
+    if (tind == 0)
+    {
+        gindShared = iu[dindLocal] + GSIZE * iv[dindLocal] - support;
+        cindShared = cOffset[dindLocal];
+        dataLocal = data[dindLocal];
+    }
+    __syncthreads();
+
+    for (int row = 0; row < SSIZE; ++row)
+    {
+        // Make a local copy from shared memory
+        int gind = gindShared + GSIZE * row;
+        int cind = cindShared + SSIZE * row;
+
+        if (tind < SSIZE)
+        {
+            //grid[gind + tind] = hipCfmaf(dataLocal, C[cind + tind], grid[gind + tind]);
+            const Complex tmp = hipCmulf(dataLocal, C[cind + tind]);
+            //grid[gind + tind] = hipCaddf(grid[gind + tind], tmp);
+            //atomicAdd(&grid[gind + tind].x, tmp.x);
+            //atomicAdd(&grid[gind + tind].y, tmp.y);
+            atomicAdd(&grid[gind].x+2*tind,   tmp.x);
+            atomicAdd(&grid[gind].x+2*tind+1, tmp.y);
+            //unsafeAtomicAdd(&grid[gind + tind].x, tmp.x);
+            //unsafeAtomicAdd(&grid[gind + tind].y, tmp.y);
+        }
+
+    }
+
 }

--- a/gpuPacer2022/codes/HIP/gridding/version1/src/gridKernelGPU.hip
+++ b/gpuPacer2022/codes/HIP/gridding/version1/src/gridKernelGPU.hip
@@ -62,35 +62,20 @@ void devGridKernel2(
     const int dind)
 {
 
+    const int SSIZE = 2 * support + 1;
+    assert(SSIZE == blockDim.x);
+
     const int bind = blockIdx.x;
     const int tind = threadIdx.x;
 
     const int dindLocal = dind + bind;
+    const Complex dataLocal = data[dindLocal];
 
-    const int SSIZE = 2 * support + 1;
-    assert(SSIZE == blockDim.x);
-
-    // The actual starting grid point
-    __shared__ int gindShared;
-
-    // The Convolution function point from which we offset
-    __shared__ int cindShared;
-
-    __shared__ Complex dataLocal;
-
-    if (tind == 0)
-    {
-        gindShared = iu[dindLocal] + GSIZE * iv[dindLocal] - support;
-        cindShared = cOffset[dindLocal];
-        dataLocal = data[dindLocal];
-    }
-    __syncthreads();
+    int gind = iu[dindLocal] + GSIZE * iv[dindLocal] - support;
+    int cind = cOffset[dindLocal];
 
     for (int row = 0; row < SSIZE; ++row)
     {
-        // Make a local copy from shared memory
-        int gind = gindShared + GSIZE * row;
-        int cind = cindShared + SSIZE * row;
 
         if (tind < SSIZE)
         {
@@ -100,6 +85,9 @@ void devGridKernel2(
             atomicAdd(&grid[gind].x + 2*tind,   tmp.x);
             atomicAdd(&grid[gind].x + 2*tind+1, tmp.y);
         }
+
+        gind += GSIZE;
+        cind += SSIZE;
 
     }
 

--- a/gpuPacer2022/codes/HIP/gridding/version1/src/gridKernelGPU.hip
+++ b/gpuPacer2022/codes/HIP/gridding/version1/src/gridKernelGPU.hip
@@ -97,12 +97,8 @@ void devGridKernel2(
             //grid[gind + tind] = hipCfmaf(dataLocal, C[cind + tind], grid[gind + tind]);
             const Complex tmp = hipCmulf(dataLocal, C[cind + tind]);
             //grid[gind + tind] = hipCaddf(grid[gind + tind], tmp);
-            //atomicAdd(&grid[gind + tind].x, tmp.x);
-            //atomicAdd(&grid[gind + tind].y, tmp.y);
-            atomicAdd(&grid[gind].x+2*tind,   tmp.x);
-            atomicAdd(&grid[gind].x+2*tind+1, tmp.y);
-            //unsafeAtomicAdd(&grid[gind + tind].x, tmp.x);
-            //unsafeAtomicAdd(&grid[gind + tind].y, tmp.y);
+            atomicAdd(&grid[gind].x + 2*tind,   tmp.x);
+            atomicAdd(&grid[gind].x + 2*tind+1, tmp.y);
         }
 
     }

--- a/gpuPacer2022/codes/HIP/gridding/version1/utilities/MaxError.cpp
+++ b/gpuPacer2022/codes/HIP/gridding/version1/utilities/MaxError.cpp
@@ -27,7 +27,7 @@ void MaxError<complex<float>>::maxError(const std::vector<complex<float>>& v1, c
                 maximumErrorReal = abs(v1[i].real() - v2[i].real());
                 index = i;
                 cout << "Maximum Error: (" << maximumErrorReal << ", " << maximumErrorImag << "), at index: " << index << endl;
-                exit(-1);
+                //exit(-1);
             }
         }
         cout << "Maximum Error: (" << maximumErrorReal << ", " << maximumErrorImag << ")" << endl;


### PR DESCRIPTION
Updates for gpuPacer2022/codes/HIP/[de]gridding/version1/

May not want to actually merge this in, except perhaps the changes to GridderGPU.hip and gridKernelGPU.hip.

The updated degridding code works fine, but does the merge over the full shared memory vectors, rather than splitting into warp reductions. 

The CUDA version has not been updated. I figured I would wait until we decide what to include in version2.